### PR TITLE
Fix display issues when scrolling

### DIFF
--- a/memories/index.css
+++ b/memories/index.css
@@ -3,15 +3,21 @@
 body {
     padding:0px;
     margin:0px;
-    background:linear-gradient(0deg,rgba(0,0,0,0.5),rgb(0, 0, 0)),url("https://i.imgur.com/2TX6U1a.jpeg"), center center;
-    backdrop-filter: blur(5px);
-    background-size:cover;
-    width:100vw;
-    height:100vh;
     overflow-x:hidden;
     overflow-y:auto;
     font-family: 'Josefin Sans', sans-serif;
 }
+
+.background {
+    position: fixed;
+    top:0;
+    width:100vw;
+    height:100vh;
+    background:linear-gradient(0deg,rgba(0,0,0,0.5),rgb(0, 0, 0)),url("https://i.imgur.com/2TX6U1a.jpeg"), center center;
+    background-size:cover;
+    filter: blur(5px);
+}
+
 #loading {
     width: 100vw;
     height: 100vh;
@@ -69,16 +75,14 @@ body {
 }
 #middle {
     width:100vw;
-    height:90vh;
+    min-height:100vh;
     display:flex;
     flex-direction:column;
     justify-content:center;
-    position:fixed;
     top:0;
     text-align:center;
     z-index:1;
     color:#fff;
-    padding-bottom:10vh;
 }
 #middle h1 {
     color:rgb(255, 50, 50);
@@ -189,30 +193,34 @@ body {
     color:rgb(255, 50, 50);
 }
 .container {
-    width:90vw;
+    position:fixed;
+    top:0;
+    width:100vw;
     height:100vh;
-    padding:5vh 5vw;
     background:rgba(230, 144, 45, 0.975);
     color:#fff;
     z-index:9;
-    position:fixed;
     max-height:100vh;
-    overflow-y:auto;
     display:none;
-}
-.container div {
-    font-size:25px;
-    margin:20px 0px;
-    transition:0.4s ease-in-out;
-}
-.container div:hover {
-    cursor:pointer;
 }
 .container section {
     margin:8vh 0px;
 }
+.container .container__content {
+    position:absolute;
+    top:0;
+    bottom:0;
+    overflow-y:auto;
+    width:100%;
+}
 .container .back_arrow {
-    margin:0px;
+    margin-top:20px;
+    margin-left:20px;
+    font-size:25px;
+    transition:0.4s ease-in-out;
+}
+.container .back_arrow:hover {
+    cursor:pointer;
 }
 
 #used div{
@@ -320,12 +328,10 @@ body {
 }
 #footer {
     color:#fff;
-    width:92vw;
     padding:5vh 4vw;
     text-align:right;
-    position:fixed;
     z-index:1;
-    bottom:0;
+    margin-top:auto;
     font-size:16px;
     font-weight:bold;
 }

--- a/memories/index.css
+++ b/memories/index.css
@@ -409,26 +409,37 @@ body {
     z-index: 10; /* Sit on top */
     left: 0;
     top: 0;
-    width: 100%; /* Full width */
-    height: 100%; /* Full height */
-    overflow: auto; /* Enable scroll if needed */
+    width: 100vw; /* Full width */
+    height: 100vh; /* Full height */
     background-color: rgb(0,0,0); /* Fallback color */
 }
 
 
 /* Modal Content (image) */
 .modal-content {
-    margin: auto;
-    position: fixed;
     display: block;
+    position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
     right: 0;
-    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
     max-width: 700px;
+    min-height: 100%;
+    overflow: auto;
 }
 
+.modal-image {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    margin: auto;
+}
 
 /* The Close Button */
 .close {
@@ -450,12 +461,11 @@ body {
 
 /* 100% Image Width on Smaller Screens */
 @media only screen and (max-width: 700px) {
-    .modal-content {
-        width: 100%;
-    }
-}
+  .modal-content {
+    width: 100%;
+  }
 
-.modal-content, #caption {  
+  .modal-content, #caption {  
     -webkit-animation-name: zoom;
     -webkit-animation-duration: 0.6s;
     animation-name: zoom;
@@ -489,6 +499,7 @@ body {
     text-decoration: none;
     cursor: pointer;
   }
+}
 
 
   /* segment managing popupimage ends here */

--- a/memories/index.js
+++ b/memories/index.js
@@ -68,6 +68,7 @@ var modalImg = document.getElementById("img01");
 img.onclick = function(){
   modal.style.display = "block";
   modalImg.src = this.title;
+  $("body").css({"overflow-y":"hidden"});
 }
 
 // Get the <span> element that closes the modal
@@ -76,4 +77,5 @@ var span = document.getElementsByClassName("close")[0];
 // When the user clicks on <span> (x), close the modal
 span.onclick = function() {
   modal.style.display = "none";
+  $("body").css({"overflow-y":"auto"});
 }

--- a/memories/index.js
+++ b/memories/index.js
@@ -1,12 +1,14 @@
 function showabout(){
     $("#about_container").css("display","inherit");
     $("#about_container").addClass("animated slideInLeft");
+    $("body").css({"overflow-y":"hidden"});
     setTimeout(function(){
         $("#about_container").removeClass("animated slideInLeft");
     },800);
 }
 function closeabout(){
     $("#about_container").addClass("animated slideOutLeft");
+    $("body").css({"overflow-y":"auto"});
     setTimeout(function(){
         $("#about_container").removeClass("animated slideOutLeft");
         $("#about_container").css("display","none");
@@ -15,12 +17,14 @@ function closeabout(){
 function showwork(){
     $("#work_container").css("display","inherit");
     $("#work_container").addClass("animated slideInRight");
+    $("body").css({"overflow-y":"hidden"});
     setTimeout(function(){
         $("#work_container").removeClass("animated slideInRight");
     },800);
 }
 function closework(){
     $("#work_container").addClass("animated slideOutRight");
+    $("body").css({"overflow-y":"auto"});
     setTimeout(function(){
         $("#work_container").removeClass("animated slideOutRight");
         $("#work_container").css("display","none");
@@ -29,12 +33,14 @@ function closework(){
 function showcontact(){
     $("#contact_container").css("display","inherit");
     $("#contact_container").addClass("animated slideInUp");
+    $("body").css({"overflow-y":"hidden"});
     setTimeout(function(){
         $("#contact_container").removeClass("animated slideInUp");
     },800);
 }
 function closecontact(){
     $("#contact_container").addClass("animated slideOutDown");
+    $("body").css({"overflow-y":"auto"});
     setTimeout(function(){
         $("#contact_container").removeClass("animated slideOutDown");
         $("#contact_container").css("display","none");

--- a/memories/p1/index.html
+++ b/memories/p1/index.html
@@ -62,7 +62,9 @@
         Modal image
     -->
     <div id="myModal" class="modal">
-        <img class="modal-content" id="img01">
+        <div class="modal-content">
+            <img class="modal-image" id="img01">
+        </div>
         <span class="close">&times;</span>
     </div>
 

--- a/memories/p1/index.html
+++ b/memories/p1/index.html
@@ -17,6 +17,7 @@
     <div id="loading">
         <div id="spinner"></div>
     </div>
+    <div class="background"></div>
     <div id="particles-js"></div>
     <div id="box">
         <div class="box1 onlywide animated bounceOutLeft" style="animation-delay:1.7s;"></div>
@@ -51,6 +52,10 @@
                     <td class="animated zoomIn" style="animation-delay:2.4s;"><button class="btn_one" onclick="location.href='../../index.html'" type="button">回彼記主頁</button></tr>
                 </tr>
         </table>
+
+        <div id="footer">
+            <a>2022 Peter Note</a>
+        </div>
     </div>
 
     <!--
@@ -65,7 +70,8 @@
         1F
     -->
     <div id="work_container" class="container">
-        <div onclick="closework()" class="back_arrow"><i class="fas fa-angle-right"></i></div>
+        <div class="container__content">
+            <div onclick="closework()" class="back_arrow"><i class="fas fa-angle-right"></i></div>
             <center>
                 <h2 style="color: white; text-shadow: 4px 4px 5px black;">選擇欲嘗試解鎖之影片：</h2>
                 <table>
@@ -81,15 +87,16 @@
                     </tr>
                 </table>
             </center>
+        </div>
     </div>
-    
 
 
     <!--
         B1
     -->
     <div id="about_container" class="container">
-        <div onclick="closeabout()" class="back_arrow"><i class="fas fa-angle-left"></i></div>
+        <div class="container__content">
+            <div onclick="closeabout()" class="back_arrow"><i class="fas fa-angle-left"></i></div>
             <center>
                 <h2 style="color: white; text-shadow: 4px 4px 5px black;">選擇欲嘗試解鎖之影片：</h2>
                 <table>
@@ -105,15 +112,7 @@
                     </tr>
                 </table>
             </center>
-    </div>    
-
-
-    <!--
-        bottom of page
-    -->
-    <div id="footer">
-        <!-- Brought to you by <a href="https://www.hwaining.org/">Hwaining Baptist Church</a><br> -->
-        <a>2022 Peter Note</a>
+        </div>
     </div>
 
 

--- a/memories/p2/index.html
+++ b/memories/p2/index.html
@@ -17,6 +17,7 @@
     <div id="loading">
         <div id="spinner"></div>
     </div>
+    <div class="background"></div>
     <div id="particles-js"></div>
     <div id="box">
         <div class="box1 onlywide animated bounceOutLeft" style="animation-delay:1.7s;"></div>
@@ -53,6 +54,10 @@
                     <td class="animated zoomIn" style="animation-delay:2.4s;"><button class="btn_one" onclick="location.href='../../index.html'" type="button">回彼記主頁</button></td>
                 </tr>
         </table>
+
+        <div id="footer">
+            <a>2022 Peter Note</a>
+        </div>
     </div>
 
     <!--
@@ -67,28 +72,33 @@
         1F
     -->
     <div id="work_container" class="container">
-        <div onclick="closework()" class="back_arrow"><i class="fas fa-angle-right"></i></div>
+        <div class="container__content">
+            <div onclick="closework()" class="back_arrow"><i class="fas fa-angle-right"></i></div>
             <center>
                 <h2 style="color: white; text-shadow: 4px 4px 5px black;">本樓無謎題！</h2>
             </center>
+        </div>
     </div>
-    
+
     <!--
         3F
     -->
     <div id="contact_container" class="container">
-        <div onclick="closecontact()" class="back_arrow"><i class="fas fa-angle-down"></i></div>
+        <div class="container__content">
+            <div onclick="closecontact()" class="back_arrow"><i class="fas fa-angle-down"></i></div>
             <center>
                 <h2>女友房間</h2>
                 <p>去晴子談談吧~！</p>
             </center>
+        </div>
     </div>
 
     <!--
         B1
     -->
     <div id="about_container" class="container">
-        <div onclick="closeabout()" class="back_arrow"><i class="fas fa-angle-left"></i></div>
+        <div class="container__content">
+            <div onclick="closeabout()" class="back_arrow"><i class="fas fa-angle-left"></i></div>
             <center>
                 <h2 style="color: white; text-shadow: 4px 4px 5px black;">選擇欲嘗試解鎖之影片：</h2>
                 <table>
@@ -103,15 +113,7 @@
                     </tr>
                 </table>
             </center>
-    </div>    
-
-
-    <!--
-        bottom of page
-    -->
-    <div id="footer">
-        <!-- Brought to you by <a href="https://www.hwaining.org/">Hwaining Baptist Church</a><br> -->
-        <a>2022 Peter Note</a>
+        </div>
     </div>
 
 

--- a/memories/p3/index.html
+++ b/memories/p3/index.html
@@ -19,6 +19,7 @@
     <div id="loading">
         <div id="spinner"></div>
     </div>
+    <div class="background"></div>
     <div id="particles-js"></div>
     <div id="box">
         <div class="box1 onlywide animated bounceOutLeft" style="animation-delay:1.7s;"></div>
@@ -53,6 +54,10 @@
                     <td class="animated zoomIn" style="animation-delay:2.4s;"><button class="btn_one" onclick="location.href='../../index.html'" type="button">回彼記主頁</button></tr>
                 </tr>
         </table>
+
+        <div id="footer">
+            <a>2022 Peter Note</a>
+        </div>
     </div>
 
     <!--
@@ -67,6 +72,7 @@
         1F
     -->
     <div id="work_container" class="container">
+        <div class="container__content">
         <div onclick="closework()" class="back_arrow"><i class="fas fa-angle-right"></i></div>
             <center>
                 <!-- <h1>二至五樓</h1> -->
@@ -89,14 +95,14 @@
                 </table>
             </center>
     </div>
-    
 
 
     <!--
         B1
     -->
     <div id="about_container" class="container">
-        <div onclick="closeabout()" class="back_arrow"><i class="fas fa-angle-left"></i></div>
+        <div class="container__content">
+            <div onclick="closeabout()" class="back_arrow"><i class="fas fa-angle-left"></i></div>
             <center>
                 <!-- <h1>地下室</h1> -->
                 <h2 style="color: white; text-shadow: 4px 4px 5px black;">選擇欲嘗試解鎖之影片：</h2>
@@ -120,15 +126,7 @@
                     </tr> -->
                 </table>
             </center>
-    </div>    
-
-
-    <!--
-        bottom of page
-    -->
-    <div id="footer">
-        <!-- Brought to you by <a href="https://www.hwaining.org/">Hwaining Baptist Church</a><br> -->
-        <a>2022 Peter Note</a>
+        </div>
     </div>
 
 


### PR DESCRIPTION
Several display problems will show up when the viewport height is less than about 306px (for example when mobile device is in landscape mode):

1. The title "彼記-回憶大廳" goes out of the viewport.
2. The "2022 Peter Note" footer overlaps with "回彼記主頁".
3. The background image doesn't fill the whole page when scrolling to the bottom.

The core of all these problems lies in the fundamental design of the page layout. In particular, the "middle" div is specified as fixed-positioned, leaving its content to be likely to overflow on screens with small height. Currently the "middle" div seems to be scrollable only because of the "backdrop-filter" attribute set for the body (see https://stackoverflow.com/questions/52937708).

In this commit we solve the problems altogether (hopefully). Major changes are:

1. Applying "backdrop-filter" to the body is equivalent to applying "filter" to the background image. Therefore, move the background image to its own div to prevent affecting the positioning of the other elements in the page. Note that now the background image doesn't move when scrolling (no special reason for that, but I just think it's easier to implement).
2. IMO the footer doesn't have to be fixed-positioned, so move it within the "middle" div.
3. Allow scrolling the "container" divs (e.g. "about_container"), while making sure its orange background covers the whole viewport. For this to work, the "overflow-y" of the body needs to be set to "hidden" when the div is opened. After the change the "container" itself is fixed, but the content "container__content" is scrollable.